### PR TITLE
Fixes the crash problem with the Xcode custom code library

### DIFF
--- a/XActivatePowerMode/XPowerModeCommand.h
+++ b/XActivatePowerMode/XPowerModeCommand.h
@@ -21,3 +21,4 @@
 + (instancetype)commandWithSource:(id)source position:(CGPoint)position;
 
 @end
+

--- a/XActivatePowerMode/XPowerModeCommand.m
+++ b/XActivatePowerMode/XPowerModeCommand.m
@@ -13,8 +13,12 @@
 + (instancetype)commandWithSource:(id)source position:(CGPoint)position
 {
     XPowerModeCommand * command = [XPowerModeCommand new];
-    command.source = source;
+    
     command.position = position;
+    
+   
+    command.source = source;
+    
     return command;
 }
 

--- a/XActivatePowerMode/XPowerModeCommander.m
+++ b/XActivatePowerMode/XPowerModeCommander.m
@@ -83,10 +83,14 @@
         XPowerModeCommand * command = [XPowerModeCommand commandWithSource:textView position:targetRect.origin];
         
         [self.heros enumerateObjectsUsingBlock:^(id<XPowerModeHero> _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            
             if ( obj && [obj respondsToSelector:@selector(onPowerModeCommand:)])
             {
+                
                 [obj onPowerModeCommand:command];
+                
             }
+            
         }];
     }
 }

--- a/XActivatePowerMode/XPowerModeHeros/Emitter/Emitter.m
+++ b/XActivatePowerMode/XPowerModeHeros/Emitter/Emitter.m
@@ -38,6 +38,12 @@ NSString * const kXActivatePowerModeEffectFile = @"qfi.sh.xcodeplugin.activatepo
     
     NSView * view = aView.superview;
 
+    // Fixes the crash problem with the Xcode custom code library
+    if ([view isKindOfClass:NSClassFromString(@"DVTControllerContentView")]) {
+        NSWindow *tmpWindow = (NSWindow *)view;
+        view = tmpWindow.contentView;
+    }
+
     if ( !self.isEmitting )
     {
         [self startAtPosition:position onView:view];


### PR DESCRIPTION
在给 Xcode 添加自定义代码库的时候，我选择 edit 编辑代码，但是 Xcode 奔溃了，看了奔溃日志后，修复这个插件的问题
